### PR TITLE
Allow @log_api_call decorator to be applied to multiple routes

### DIFF
--- a/fibonacci_api/common.py
+++ b/fibonacci_api/common.py
@@ -21,8 +21,8 @@ def log_api_call(func):
 
               -- The code
 
-              @app.route('/fibonacci/foo', methods=['GET'])
               @log_api_call
+              @app.route('/fibonacci/foo', methods=['GET'])
               def fibonacci_foo_api():
                    do something interesting...
 

--- a/fibonacci_api/main.py
+++ b/fibonacci_api/main.py
@@ -24,8 +24,8 @@ def index():
 
 
 
-@app.route('/fibonacci/list', methods=['GET'])
 @log_api_call
+@app.route('/fibonacci/list', methods=['GET'])
 def fibonacci_list_api():
     """
     function:  fibonacci_api


### PR DESCRIPTION
I may be mistaken, but if the `@log_api_call` decorator follows the `@app.route` decorator the view function mapping overwrites the `log_api_call_wrapper`.  I discovered this when I tried to add the decorator to a new route.

If this is incorrect, please advise.
